### PR TITLE
fix: update ALB health check path

### DIFF
--- a/modules/keycloak/main.tf
+++ b/modules/keycloak/main.tf
@@ -50,7 +50,7 @@ module "alb" {
   certificate_arn                         = var.alb_certificate_arn
   deletion_protection_enabled             = var.deletion_protection
   health_check_interval                   = 60
-  health_check_path                       = "/auth/health"
+  health_check_path                       = "/health"
   health_check_timeout                    = 10
   http_ingress_cidr_blocks                = var.http_ingress_cidr_blocks
   http_redirect                           = var.http_redirect


### PR DESCRIPTION
Thank you for the great work on this project, it's worked almost flawlessly.

It seems that Keycloak exposes health checks on the `/health` endpoint rather than on `/auth/health`, which breaks the ALB health check, and results in the otherwise fully operational containers to be restarted.